### PR TITLE
BREAKING CHANGE: new API to import this module

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "/lib"
+    "./lib"
   ],
   "homepage": "https://github.com/mdapi-issues/listmetadata-standardvalueset",
   "keywords": [
@@ -38,7 +38,7 @@
     "MWE"
   ],
   "license": "MIT",
-  "main": "/lib/workaround.js",
+  "main": "./lib/workaround.js",
   "publishConfig": {
     "access": "public"
   },

--- a/src/workaround.ts
+++ b/src/workaround.ts
@@ -1,7 +1,7 @@
 import type { Connection, FileProperties } from 'jsforce';
 import MAPPING from './mapping';
 
-export default async function listStandardValueSets(
+export async function listStandardValueSets(
   conn: Connection
 ): Promise<Array<FileProperties>> {
   const availableStandardValueSetNames = [];

--- a/test/issue.e2e-spec.ts
+++ b/test/issue.e2e-spec.ts
@@ -1,6 +1,6 @@
 import { Org } from '@salesforce/core';
 import { expect } from 'chai';
-import listStandardValueSets from './issue';
+import { listStandardValueSets } from './issue';
 
 describe('listMetadata', function () {
   this.slow(5000);

--- a/test/issue.ts
+++ b/test/issue.ts
@@ -1,6 +1,6 @@
 import type { Connection, FileProperties } from 'jsforce';
 
-export default async function listStandardValueSets(
+export async function listStandardValueSets(
   conn: Connection
 ): Promise<Array<FileProperties>> {
   const fileProperties = await conn.metadata.list({ type: 'StandardValueSet' });

--- a/test/workaround.e2e-spec.ts
+++ b/test/workaround.e2e-spec.ts
@@ -1,6 +1,6 @@
 import { Org } from '@salesforce/core';
 import { expect } from 'chai';
-import listStandardValueSets from '../src/workaround';
+import { listStandardValueSets } from '../src/workaround';
 
 describe('workaround', function () {
   this.slow(5000);


### PR DESCRIPTION
This should improve the developer experience as described here:
https://basarat.gitbook.io/typescript/main-1/defaultisbad

- use named export instead of default export
- make the workaround the primary entry point of this module

Please migrate your code as follows:

```diff
- import listStandardValueSets from '@mdapi-issues/listmetadata-standardvalueset/lib/workaround'
+ import { listStandardValueSets } from '@mdapi-issues/listmetadata-standardvalueset'
```