### PR TITLE
chore: refactor org login from environment variable

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -28,7 +28,7 @@ jobs:
         env:
           SFDX_AUTH_URL_DEVHUB: ${{ secrets.SFDX_AUTH_URL_DEVHUB }}
         run: |
-          sfdx auth:sfdxurl:store -d -a devhub -f /dev/stdin <<< "${SFDX_AUTH_URL_DEVHUB}"
+          sfdx auth:sfdxurl:store -d -a devhub -f <(echo "${SFDX_AUTH_URL_DEVHUB}")
           yarn develop
       - name: Run end-to-end tests
         run: yarn test:e2e


### PR DESCRIPTION

Use bash process substitution which makes the input appear as a filename instead of /dev/stdin.
